### PR TITLE
Updated to write the photo object as binary for Rails 3 and Ruby 1.9.2...

### DIFF
--- a/examples/client_get_object.rb
+++ b/examples/client_get_object.rb
@@ -28,7 +28,7 @@ def handle_object(object)
         else extension = 'unknown'
     end
 
-    File.open("#{object.info['Content-ID']}_#{object.info['Object-ID']}.#{extension}", 'w') do |f|
+    File.open("#{object.info['Content-ID']}_#{object.info['Object-ID']}.#{extension}", 'wb') do |f|
         f.write(object.data)
     end
 end


### PR DESCRIPTION
With Rails 3 & Ruby 1.9.2, it will attempt to convert the object data to a string which caused a ""\xFF" from ASCII-8BIT to UTF-8" error for me.  Changing the file to open in Binary mode avoids this encoding issue.
