### PR TITLE
Update build status to use GitHub actions; support ruby 3.1+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['1.9.3', '2.0.0', '2.1.2']
+         # ruby-version: ['1.9.3', '2.0.0', '2.1.2']
+         ruby-version: ['1.9', '2.0', '2.1']
         # TODO: update to non-EOL ruby-version: ['3.1', '3.2', '3.3', '3.4']
       fail-fast: false
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-         # ruby-version: ['1.9.3', '2.0.0', '2.1.2']
-         ruby-version: ['1.9', '2.0', '2.1']
-        # TODO: update to non-EOL ruby-version: ['3.1', '3.2', '3.3', '3.4']
+         ruby-version: ['3.1', '3.2', '3.3', '3.4']
       fail-fast: false
 
     steps:

--- a/MANIFEST
+++ b/MANIFEST
@@ -1,5 +1,6 @@
 .document
 .gemtest
+.github/workflows/ci.yml
 .gitignore
 .travis.yml
 CHANGELOG

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This is the first "native" Ruby RETS library currently available, but there is a
 -   Mailing List: <rets4r@librelist.com> [Archive][]
 -   Documentation: <http://rdoc.info/github/josephholsten/rets4r>
 -   Source: <http://github.com/josephholsten/rets4r>
--   Build Status: [![Build Status](http://img.shields.io/travis/com/josephholsten/rets4r.svg)](https://app.travis-ci.com/github/josephholsten/rets4r)
+-   Build Status: [![Build Status](https://img.shields.io/github/actions/workflow/status/josephholsten/rets4r/ci.yml](https://github.com/josephholsten/rets4r/actions/workflows/ci.yml)
 -   Coverage: [![Coverage](https://img.shields.io/coveralls/josephholsten/rets4r.svg)](https://coveralls.io/r/josephholsten/rets4r)
 -   Code Climate: [![Code Climate](http://img.shields.io/codeclimate/github/josephholsten/rets4r.svg)](https://codeclimate.com/github/josephholsten/rets4r)
 

--- a/lib/rets4r/client.rb
+++ b/lib/rets4r/client.rb
@@ -422,6 +422,8 @@ module RETS4R
     #++
     def process_header(raw)
       # this util gives us arrays of values. We are only set up to handle one header value.
+      # FIXME: This assumes parsing without the fix in https://github.com/ruby/webrick/issues/137
+      # As this is only used within Auth.process_header, we need to remove it for rets4r 2.0
       WEBrick::HTTPUtils.parse_header(raw.strip).map.inject({}) do |h,(k,v)|
         h[k]=v.first; h
       end

--- a/rets4r.gemspec
+++ b/rets4r.gemspec
@@ -30,13 +30,17 @@ Gem::Specification.new do |spec|
   spec.files = File.read("MANIFEST").split(/\r?\n\r?/)
 
   spec.add_runtime_dependency 'nokogiri', '~> 1.3'
+  spec.add_runtime_dependency 'ostruct'
+  spec.add_runtime_dependency 'rexml'
   spec.add_runtime_dependency 'thor', '~> 0.19'
+  spec.add_runtime_dependency 'webrick'
+
   spec.add_development_dependency 'activesupport', '~> 4.1'
   spec.add_development_dependency 'aruba', '~> 0.6'
   spec.add_development_dependency 'cucumber', '~> 1.3'
   spec.add_development_dependency 'i18n', '~> 0.6'
   spec.add_development_dependency 'minitest', '~> 5.4'
-  spec.add_development_dependency 'mocha', '~> 1.1'
+  spec.add_development_dependency 'mocha', '~> 2.7'
   spec.add_development_dependency 'rake', '~> 10.3'
   spec.add_development_dependency 'rdoc', '~> 4.1'
   spec.add_development_dependency 'shoulda', '~> 3.5'

--- a/rets4r.gemspec
+++ b/rets4r.gemspec
@@ -30,10 +30,10 @@ Gem::Specification.new do |spec|
   spec.files = File.read("MANIFEST").split(/\r?\n\r?/)
 
   spec.add_runtime_dependency 'nokogiri', '~> 1.3'
-  spec.add_runtime_dependency 'ostruct'
-  spec.add_runtime_dependency 'rexml'
+  spec.add_runtime_dependency 'ostruct', '~> 0.6.1'
+  spec.add_runtime_dependency 'rexml', '~>3.2'
   spec.add_runtime_dependency 'thor', '~> 0.19'
-  spec.add_runtime_dependency 'webrick'
+  spec.add_runtime_dependency 'webrick', '<= 1.8.1' # we depend on flawed header parsing within Auth.parse_header, which is deprecated. Pinning to get one last release, then removing the offending code.
 
   spec.add_development_dependency 'activesupport', '~> 4.1'
   spec.add_development_dependency 'aruba', '~> 0.6'

--- a/rets4r.gemspec
+++ b/rets4r.gemspec
@@ -32,17 +32,17 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'nokogiri', '~> 1.3'
   spec.add_runtime_dependency 'ostruct', '~> 0.6.1'
   spec.add_runtime_dependency 'rexml', '~>3.2'
-  spec.add_runtime_dependency 'thor', '~> 0.19'
+  spec.add_runtime_dependency 'thor', '~> 1.3'
   spec.add_runtime_dependency 'webrick', '<= 1.8.1' # we depend on flawed header parsing within Auth.parse_header, which is deprecated. Pinning to get one last release, then removing the offending code.
 
-  spec.add_development_dependency 'activesupport', '~> 4.1'
-  spec.add_development_dependency 'aruba', '~> 0.6'
-  spec.add_development_dependency 'cucumber', '~> 1.3'
-  spec.add_development_dependency 'i18n', '~> 0.6'
+  spec.add_development_dependency 'activesupport', '~> 7.0'
+  spec.add_development_dependency 'aruba', '~> 2.3'
+  spec.add_development_dependency 'cucumber', '~> 9.2'
+  spec.add_development_dependency 'i18n', '~> 1.14'
   spec.add_development_dependency 'minitest', '~> 5.4'
   spec.add_development_dependency 'mocha', '~> 2.7'
-  spec.add_development_dependency 'rake', '~> 10.3'
-  spec.add_development_dependency 'rdoc', '~> 4.1'
-  spec.add_development_dependency 'shoulda', '~> 3.5'
+  spec.add_development_dependency 'rake', '~>13.2'
+  spec.add_development_dependency 'rdoc', '~>6.14'
+  spec.add_development_dependency 'shoulda', '~> 4.0'
 end
 

--- a/test/test_client_get_object.rb
+++ b/test/test_client_get_object.rb
@@ -5,6 +5,8 @@ require 'test_helper'
 
 require 'rets4r/client'
 
+require 'webrick/httpstatus'
+
 class TestClientGetObject < Minitest::Test
     RETS_PORT     = '9080'
     RETS_URL      = "http://localhost:#{RETS_PORT}"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,7 +3,7 @@ $LOAD_PATH.unshift(libdir) unless $LOAD_PATH.include?(libdir)
 $VERBOSE = true
 
 require 'minitest/autorun'
-require 'mocha/mini_test'
+require 'mocha/minitest'
 require 'shoulda'
 require 'pathname'
 


### PR DESCRIPTION
Required some dependency pinning to accommodate the removal of improper HTTP header parsing in webrick. As this is only called from deprecated code, this pin will be removable by code removal in rets4r 2.